### PR TITLE
#1 V0.2.4 Implement Adapters

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -35,9 +35,8 @@
             },
 
             shim:{
-                app: {
-                    deps:['underscore','jquery', 'backbone', 'marionette'],
-                    exports: 'app'
+                mf: {
+                    deps:['underscore','jquery', 'backbone', 'marionette']
                 }
             }
         },[
@@ -47,18 +46,14 @@
         });
 
 
-        define('app', ['mf', 'jquery', 'backbone', 'marionette'], function($, Backbone, Marionette, mf){
+        define('app', ['mf'], function($, Backbone, Marionette, mf){
 
             return window.app = window.app ? window.app : new MF({
                 paths:{
                     main: 'sample-project/js/',
                     component: 'sample-project/js/components/'
                 },
-                globals: {
-                    $: $,
-                    Backbone: Backbone,
-                    Marionette: Marionette
-                },
+                globals: ['$', 'Backbone', 'Marionette'],
                 html: true
             });
         });

--- a/test/specs/LoadView.js
+++ b/test/specs/LoadView.js
@@ -5,12 +5,8 @@ define(['app'], function(app){
 
         beforeEach(function(done) {
             setFixtures('<div id="main-view"/>');
-            app.load({type:'view', name: 'view', el:"#main-view"}).then(function(_r){
-                view = new _r();
-                view.render();
-                console.log(view);
-                console.log(view.$el);
-                console.log(view.el);
+            app.init({type:'view', name: 'view', el:"#main-view"}).then(function(_r){
+                view = _r;
                 done();
             });
         });
@@ -34,7 +30,7 @@ define(['app'], function(app){
 
         beforeEach(function(done) {
             setFixtures('<div id="main-view"/>');
-            app.load({type:'view', name: 'view',
+            app.init({type:'view', name: 'view',
                 extend: { _text: 'something', _function : function(){}, _obj: {}  },
                 el:"#main-view"}).then(function(_r){
                 view = _r;


### PR DESCRIPTION
Solving issue #1:
- Removing Backbone and Marionette has dependency.
- Deliver the first _mode_ `Backbone`, in this way is possible to use both Backbone or Marionette.
- Removing defaults globals, now is possible to add default global for your framework in order to expose under your custom key, defaults: `app._` and `app.$`.
- Now the only 3 dependency are RequireJS, Underscore, jQuery.
- provide methods `adapter`, `addMode`, `global` for add adapters or global,
- Add option `mode` for choose your favorite set of adapters.
